### PR TITLE
[12.0][product_dimension] Update volume when dimension are updated by file import

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -9,6 +9,7 @@
     'author': 'brain-tec AG, ADHOC SA, Camptocamp SA, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
+    'website': 'https://github.com/OCA/product-attribute',
     'depends': ['product'],
     'data': ['views/product_view.xml'],
     'installable': True,

--- a/product_dimension/models/product.py
+++ b/product_dimension/models/product.py
@@ -64,4 +64,4 @@ class ProductTemplate(models.Model):
     dimensional_uom_id = fields.Many2one(
         'uom.uom',
         'Dimensional UoM', related='product_variant_ids.dimensional_uom_id',
-        help='UoM for length, height, width')
+        help='UoM for length, height, width', readonly=False)

--- a/product_dimension/models/product.py
+++ b/product_dimension/models/product.py
@@ -6,8 +6,54 @@
 from odoo import models, fields, api
 
 
+class ProductVolumeMixin(models.AbstractModel):
+    _name = 'product.volume.mixin'
+    _description = 'Product Volume Mixin'
+
+    def create(self, vals_list):
+        # recompute volume when dimensions are created from import because
+        # onchange won't have any effect on this case.
+        if self.env.context.get('import_file'):
+            dimension_fields = [
+                'length', 'height', 'width', 'dimensional_uom_id'
+            ]
+            for vals in vals_list:
+                if (all([vals.get(key) for key in dimension_fields]) and
+                        'volume' not in vals):
+                    dimensional_uom = self.env['uom.uom'].browse(
+                        vals['dimensional_uom_id'])
+                    volume = self.env['product.template']._calc_volume(
+                        vals['length'], vals['height'], vals['width'],
+                        dimensional_uom)
+                    vals['volume'] = volume
+        return super().create(vals_list)
+
+    def write(self, vals):
+        # recompute volume when dimensions are updated from import because
+        # onchange won't have any effect on this case.
+        # write from import can only update 1 product at a time?
+        if (self.env.context.get('import_file') and 'volume' not in vals and
+                len(self) == 1):
+            dimension_fields = [
+                'length', 'height', 'width', 'dimensional_uom_id'
+            ]
+            if any([key in dimension_fields for key in vals.keys()]):
+                length = 'length' in vals and vals['length'] or self.length
+                height = 'height' in vals and vals['height'] or self.height
+                width = 'width' in vals and vals['width'] or self.width
+                dimensional_uom = ('dimensional_uom_id' in vals and
+                                   self.env['uom.uom'].browse(
+                                       vals['dimensional_uom_id']) or
+                                   self.dimensional_uom_id)
+                volume = self.env['product.template']._calc_volume(
+                    length, height, width, dimensional_uom)
+                vals['volume'] = volume
+        return super().write(vals)
+
+
 class Product(models.Model):
-    _inherit = 'product.product'
+    _name = 'product.product'
+    _inherit = ['product.product', 'product.volume.mixin']
 
     @api.onchange('length', 'height', 'width', 'dimensional_uom_id')
     def onchange_calculate_volume(self):
@@ -31,7 +77,8 @@ class Product(models.Model):
 
 
 class ProductTemplate(models.Model):
-    _inherit = 'product.template'
+    _name = 'product.template'
+    _inherit = ['product.template', 'product.volume.mixin']
 
     @api.model
     def _calc_volume(self, length, height, width, uom_id):

--- a/product_dimension/readme/CONTRIBUTORS.rst
+++ b/product_dimension/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* Juan Jose Scarafia <jjs@ingadhoc.com>
+* Leonardo Pistone <leonardo.pistone@camptocamp.com>
+* Denis Leemann <denis.leemann@camptocamp.com>
+* Kumar Aberer <kumar.aberer@braintec-group.com>

--- a/product_dimension/readme/DESCRIPTION.rst
+++ b/product_dimension/readme/DESCRIPTION.rst
@@ -1,0 +1,6 @@
+This module extends the functionality of product to support
+dimensions (length, width and height). Find the volume
+automatically when you change one of these dimensions.
+
+This module was previously hosted on https://github.com/ingadhoc/odoo-addons
+and before that on https://launchpad.net/~ingenieria-adhoc.

--- a/product_dimension/tests/test_compute_volume.py
+++ b/product_dimension/tests/test_compute_volume.py
@@ -27,6 +27,36 @@ class TestComputeVolumeOnProduct(TransactionCase):
             self.product.volume
         )
 
+    def test_it_computes_volume_from_write_import(self):
+        vals = {
+            'length': 6,
+            'height': 2,
+            'width': 10,
+            'dimensional_uom_id': self.uom_m.id,
+        }
+        product = self.env['product.product'].create({'name': 'test'})
+        prod = product.with_context(import_file=True)
+        prod.write(vals)
+        self.assertAlmostEqual(
+            120,
+            prod.volume
+        )
+
+    def test_it_computes_volume_from_create_import(self):
+        vals = {
+            'name': 'Test',
+            'length': 6,
+            'height': 2,
+            'width': 10,
+            'dimensional_uom_id': self.uom_m.id,
+        }
+        product = self.env['product.product'].with_context(import_file=True).\
+            create(vals)
+        self.assertAlmostEqual(
+            120,
+            product.volume
+        )
+
     def setUp(self):
         super(TestComputeVolumeOnProduct, self).setUp()
 
@@ -57,6 +87,35 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.assertAlmostEqual(
             120,
             self.template.volume
+        )
+
+    def test_it_computes_volume_from_import(self):
+        vals = {
+            'length': 6,
+            'height': 2,
+            'width': 10,
+            'dimensional_uom_id': self.uom_m.id,
+        }
+        tmpl = self.template.with_context(import_file=True)
+        tmpl.write(vals)
+        self.assertAlmostEqual(
+            120,
+            tmpl.volume
+        )
+
+    def test_it_computes_volume_from_create_import(self):
+        vals = {
+            'name': 'Test',
+            'length': 6,
+            'height': 2,
+            'width': 10,
+            'dimensional_uom_id': self.uom_m.id,
+        }
+        template = self.env['product.template'].with_context(
+            import_file=True).create(vals)
+        self.assertAlmostEqual(
+            120,
+            template.volume
         )
 
     def setUp(self):


### PR DESCRIPTION
Hi @rvalyi 
Could you give me a feedback on this PR?
First commit complete the migration (split readme + remove readonly on dimension, it seems you forgot this one)

Second commit : the goal is to update the volume even when dimensions are not updated from the UI.
I only manage file importing, I don't see another way to create product (in native Odoo modules) and if modules create/write on products, I guess they should play the onchanges themselves...

What do you think? I made a mixin to avoid duplicating code, but maybe it is not a good practice to make a so small mixin?
Also, I assume that when importing file, Odoo make one write by record, but I am not totally sure, I'll try to make some tests to be sure.

Anyway, if you are not sure about the second commit, we could make the first commit in your branch, merge it into OCA and I'll do a second PR with second commit...It could even go into a separated module but I don't think it should!