### PR TITLE
[ADD] product_category_type fr translation

### DIFF
--- a/product_category_type/i18n/fr.po
+++ b/product_category_type/i18n/fr.po
@@ -1,0 +1,56 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * product_category_type
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-24 16:47+0000\n"
+"PO-Revision-Date: 2023-02-24 16:47+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_category_type
+#: model:ir.model.fields,help:product_category_type.field_product_category__type
+msgid ""
+"A category of the view type is a virtual category that can be used as the "
+"parent of another category to create a hierarchical structure."
+msgstr "Une catégorie de type vue est une catégorie virtuelle qui est utilisée comme "
+" parent d'une autre catégorie, pour créer une structure hiérarchique."
+
+#. module: product_category_type
+#: model:ir.model.fields,field_description:product_category_type.field_product_category__type
+msgid "Category Type"
+msgstr "Type de catégorie"
+
+#. module: product_category_type
+#: model:ir.model.fields.selection,name:product_category_type.selection__product_category__type__normal
+msgid "Normal"
+msgstr ""
+
+#. module: product_category_type
+#: model:ir.model.fields,field_description:product_category_type.field_product_category__parent_id
+msgid "Parent Category"
+msgstr "Catégorie mère"
+
+#. module: product_category_type
+#: model:ir.model,name:product_category_type.model_product_template
+msgid "Product"
+msgstr "Produit"
+
+#. module: product_category_type
+#: model:ir.model,name:product_category_type.model_product_category
+#: model:ir.model.fields,field_description:product_category_type.field_product_product__categ_id
+#: model:ir.model.fields,field_description:product_category_type.field_product_template__categ_id
+msgid "Product Category"
+msgstr "Catégorie de produit"
+
+#. module: product_category_type
+#: model:ir.model.fields.selection,name:product_category_type.selection__product_category__type__view
+msgid "View"
+msgstr "Vue"


### PR DESCRIPTION
@PierrickBrun. 
je profite de ta migration V16 pour inclure la traduction fr.po, que j'avais oublié quand j'avais développé le module en V12.

merci ! 