### PR TITLE
[UPD] Updated 'on demand' feature

### DIFF
--- a/product_stock_state/__manifest__.py
+++ b/product_stock_state/__manifest__.py
@@ -7,8 +7,11 @@
 
 {
     "name": "Product Stock State",
-    "summary": "Compute the state of a product's stock"
-    "the stock level and sale_ok field",
+    "summary": """Compute the state of a product's stock
+        Offers 'sale ok' field
+        Tracks the stock level and manage the following product's stock states based on rules :
+        'on demand' 'in_stock' 'limited stock' 'resupplying' 'out of stock'
+    """,
     "version": "14.0.1.0.1",
     "website": "https://github.com/OCA/product-attribute",
     "author": " Akretion, GRAP, Odoo Community Association (OCA)",

--- a/product_stock_state/i18n/fr.po
+++ b/product_stock_state/i18n/fr.po
@@ -91,6 +91,12 @@ msgid "Manual Stock State Threshold"
 msgstr "Seuil pour l'état du stock manuel"
 
 #. module: product_stock_state
+#: model:ir.model.fields,field_description:product_stock_state.field_product_product__on_demand
+#: model:ir.model.fields,field_description:product_stock_state.field_product_template__on_demand
+msgid "On Demand"
+msgstr "A la demande"
+
+#. module: product_stock_state
 #: model:ir.model,name:product_stock_state.model_product_product
 msgid "Product"
 msgstr "Article"
@@ -173,6 +179,12 @@ msgstr ""
 "cette catégorie passera de l'état \"En stock\" à \"En stock limité\". Si "
 "elle n'est pas définie, Odoo utilisera le seuil défini au niveau de "
 "l'entreprise."
+
+#. module: product_stock_state
+#: model:ir.model.fields,help:product_stock_state.field_product_product__on_demand
+#: model:ir.model.fields,help:product_stock_state.field_product_template__on_demand
+msgid "This field allows you to force the stock state to the on-demand value"
+msgstr "Ce champs vous permet de forcer l'état du stock à 'A la demande'"
 
 #. module: product_stock_state
 #: model:product.product,uom_name:product_stock_state.product_setting_by_company

--- a/product_stock_state/i18n/fr.po
+++ b/product_stock_state/i18n/fr.po
@@ -94,7 +94,12 @@ msgstr "Seuil pour l'état du stock manuel"
 #: model:ir.model.fields,field_description:product_stock_state.field_product_product__on_demand
 #: model:ir.model.fields,field_description:product_stock_state.field_product_template__on_demand
 msgid "On Demand"
-msgstr "A la demande"
+msgstr "Sur demande"
+
+#. module: product_stock_state
+#: model:ir.model.fields,help:product_stock_state.field_product_template_on_demand
+msgid "This field allows you to force the stock state to the on-demand value"
+msgstr "Ce champ vous permet de forcer l'état du stock à 'À la demande'"
 
 #. module: product_stock_state
 #: model:ir.model,name:product_stock_state.model_product_product

--- a/product_stock_state/i18n/product_stock_state.pot
+++ b/product_stock_state/i18n/product_stock_state.pot
@@ -80,6 +80,12 @@ msgid "Manual Stock State Threshold"
 msgstr ""
 
 #. module: product_stock_state
+#: model:ir.model.fields,field_description:product_stock_state.field_product_product__on_demand
+#: model:ir.model.fields,field_description:product_stock_state.field_product_template__on_demand
+msgid "On Demand"
+msgstr ""
+
+#. module: product_stock_state
 #: model:ir.model,name:product_stock_state.model_product_product
 msgid "Product"
 msgstr ""

--- a/product_stock_state/i18n/product_stock_state.pot
+++ b/product_stock_state/i18n/product_stock_state.pot
@@ -86,6 +86,11 @@ msgid "On Demand"
 msgstr ""
 
 #. module: product_stock_state
+#: model:ir.model.fields,help:product_stock_state.field_product_template__on_demand
+msgid "This field allows you to force the stock state to the on-demand value"
+msgstr ""
+
+#. module: product_stock_state
 #: model:ir.model,name:product_stock_state.model_product_product
 msgid "Product"
 msgstr ""

--- a/product_stock_state/models/product_product.py
+++ b/product_stock_state/models/product_product.py
@@ -16,6 +16,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     _STOCK_STATE_SELECTION = [
+        ("on_demand", "On Demand"),
         ("in_stock", "In Stock"),
         ("in_limited_stock", "In Limited Stock"),
         ("resupplying", "Resupplying"),
@@ -57,6 +58,9 @@ class ProductProduct(models.Model):
     def _stock_state_check_out_of_stock(self, qty, precision):
         return True
 
+    def _stock_state_check_on_demand(self, qty, precision):
+        return self.on_demand
+
     def _available_states(self):
         return [x[0] for x in self._selection_stock_state()]
 
@@ -65,6 +69,7 @@ class ProductProduct(models.Model):
         "incoming_qty",
         "stock_state_threshold",
         "company_id.stock_state_threshold",
+        "on_demand",
     )
     def _compute_stock_state(self):
         precision = self.env["decimal.precision"].precision_get("Stock Threshold")

--- a/product_stock_state/models/product_product.py
+++ b/product_stock_state/models/product_product.py
@@ -72,6 +72,11 @@ class ProductProduct(models.Model):
         "on_demand",
     )
     def _compute_stock_state(self):
+        """
+        This method updates {stock_state} of each triggered {product}.
+        {stock_state} = first {state} where {product}_stock_state_check_{state} is True
+        {state} ordering is insured by _available_states method
+        """
         precision = self.env["decimal.precision"].precision_get("Stock Threshold")
         for product in self:
             qty_available = product._get_qty_available_for_stock_state()

--- a/product_stock_state/models/product_template.py
+++ b/product_stock_state/models/product_template.py
@@ -24,6 +24,9 @@ class ProductTemplate(models.Model):
     )
 
     manual_stock_state_threshold = fields.Float(digits="Stock Threshold")
+    on_demand = fields.Boolean(
+        help="This field allows you to force the stock state to the on-demand value"
+    )
 
     @api.depends("categ_id.stock_state_threshold", "manual_stock_state_threshold")
     def _compute_stock_state_threshold(self):

--- a/product_stock_state/models/product_template.py
+++ b/product_stock_state/models/product_template.py
@@ -24,7 +24,9 @@ class ProductTemplate(models.Model):
     )
 
     manual_stock_state_threshold = fields.Float(digits="Stock Threshold")
+
     on_demand = fields.Boolean(
+        default=False,
         help="This field allows you to force the stock state to the on-demand value"
     )
 

--- a/product_stock_state/tests/test_product_stock_state.py
+++ b/product_stock_state/tests/test_product_stock_state.py
@@ -53,3 +53,28 @@ class TestProductStockState(SavepointCase):
     def test_05_state_out_of_stock(self):
         """Test Stock State computation"""
         self.assertEqual(self.product_threshold_on_product.stock_state, "out_of_stock")
+
+    # on_demand tests
+
+    def test_06_state_on_demand_default_value(self):
+        """Test default value of on_demand"""
+        self.assertFalse(self.product_threshold_on_product.on_demand)
+
+    def test_07_on_demand_inherit(self):
+        """Test on_demand Setting (Setting on a product unique template)"""
+        self.assertEqual(
+            self.product_threshold_on_product._stock_state_check_on_demand(),
+            self.product_threshold_on_product.on_demand,
+        )
+
+    def test_08_state_on_demand_computation(self):
+        """Test on_demand = True Stock State computation 
+        stock_state is set to 'on_demand' regardless of the previous state"""
+        
+        self.product_threshold_on_product.on_demand = True
+        states = self.product_threshold_on_product._available_states()
+
+        for state in states:
+            self.product_threshold_on_product.stock_state = state
+            self.product_threshold_on_product._compute_stock_state()
+            self.assertEqual(self.product_threshold_on_product.stock_state, 'on_demand')

--- a/product_stock_state/tests/test_product_stock_state.py
+++ b/product_stock_state/tests/test_product_stock_state.py
@@ -60,16 +60,10 @@ class TestProductStockState(SavepointCase):
         - regardless of the previous state
         - regardless of the relative value of stock_state_threshold vs qty_available"""
         
-        self.product_threshold_on_product.on_demand = True
-        states = self.product_threshold_on_product._available_states()
-
         stock_state_threshold = 30
         self.product_threshold_on_product.stock_state_threshold = stock_state_threshold
+        self.product_threshold_on_product.on_demand = True
 
         for qty in [stock_state_threshold + 1, stock_state_threshold - 1]:
             self.product_threshold_on_product.qty_available = qty
-
-            for state in states:
-                self.product_threshold_on_product.stock_state = state
-                self.product_threshold_on_product._compute_stock_state()
-                self.assertEqual(self.product_threshold_on_product.stock_state, 'on_demand')
+            self.assertEqual(self.product_threshold_on_product.stock_state, 'on_demand')

--- a/product_stock_state/tests/test_product_stock_state.py
+++ b/product_stock_state/tests/test_product_stock_state.py
@@ -56,12 +56,20 @@ class TestProductStockState(SavepointCase):
 
     def test_06_state_on_demand_computation(self):
         """Test on_demand = True Stock State computation 
-        stock_state is set to 'on_demand' regardless of the previous state"""
+        stock_state is set to 'on_demand' :
+        - regardless of the previous state
+        - regardless of the relative value of stock_state_threshold vs qty_available"""
         
         self.product_threshold_on_product.on_demand = True
         states = self.product_threshold_on_product._available_states()
 
-        for state in states:
-            self.product_threshold_on_product.stock_state = state
-            self.product_threshold_on_product._compute_stock_state()
-            self.assertEqual(self.product_threshold_on_product.stock_state, 'on_demand')
+        stock_state_threshold = 30
+        self.product_threshold_on_product.stock_state_threshold = stock_state_threshold
+
+        for qty in [stock_state_threshold + 1, stock_state_threshold - 1]:
+            self.product_threshold_on_product.qty_available = qty
+
+            for state in states:
+                self.product_threshold_on_product.stock_state = state
+                self.product_threshold_on_product._compute_stock_state()
+                self.assertEqual(self.product_threshold_on_product.stock_state, 'on_demand')

--- a/product_stock_state/tests/test_product_stock_state.py
+++ b/product_stock_state/tests/test_product_stock_state.py
@@ -54,20 +54,7 @@ class TestProductStockState(SavepointCase):
         """Test Stock State computation"""
         self.assertEqual(self.product_threshold_on_product.stock_state, "out_of_stock")
 
-    # on_demand tests
-
-    def test_06_state_on_demand_default_value(self):
-        """Test default value of on_demand"""
-        self.assertFalse(self.product_threshold_on_product.on_demand)
-
-    def test_07_on_demand_inherit(self):
-        """Test on_demand Setting (Setting on a product unique template)"""
-        self.assertEqual(
-            self.product_threshold_on_product._stock_state_check_on_demand(),
-            self.product_threshold_on_product.on_demand,
-        )
-
-    def test_08_state_on_demand_computation(self):
+    def test_06_state_on_demand_computation(self):
         """Test on_demand = True Stock State computation 
         stock_state is set to 'on_demand' regardless of the previous state"""
         

--- a/product_stock_state/views/product_template_view.xml
+++ b/product_stock_state/views/product_template_view.xml
@@ -4,11 +4,18 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
+
+            <xpath expr="//div[@name='options']" position="after">
+                <div>
+                    <field name="on_demand"/>
+                    <label for="on_demand"/>
+                </div>
+            </xpath>
+
             <xpath expr="//group[@name='group_lots_and_weight']" position="after">
-                <group name="treshold" string="Stock Threshold">
-                    <field name="stock_state_threshold" />
-                    <field name="manual_stock_state_threshold" class="oe_edit_only" />
-                    <field name="on_demand" />
+                <group name="treshold" string="Stock threshold" attrs="{'invisible': [('on_demand', '=', True)]}">
+                    <field name="stock_state_threshold"/>
+                    <field name="manual_stock_state_threshold"  class="oe_edit_only"/>
                 </group>
             </xpath>
         </field>

--- a/product_stock_state/views/product_template_view.xml
+++ b/product_stock_state/views/product_template_view.xml
@@ -4,18 +4,14 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
-
-            <xpath expr="//div[@name='options']" position="after">
-                <div>
-                    <field name="on_demand"/>
-                    <label for="on_demand"/>
-                </div>
-            </xpath>
-
             <xpath expr="//group[@name='group_lots_and_weight']" position="after">
-                <group name="treshold" string="Stock threshold" attrs="{'invisible': [('on_demand', '=', True)]}">
-                    <field name="stock_state_threshold"/>
-                    <field name="manual_stock_state_threshold"  class="oe_edit_only"/>
+                <group name="treshold" string="Stock threshold">
+                    <field name="on_demand"/>
+                    <field name="stock_state_threshold" 
+                           attrs="{'invisible': [('on_demand', '=', True)]}"/>
+                    <field name="manual_stock_state_threshold"  
+                           class="oe_edit_only"
+                           attrs="{'invisible': [('on_demand', '=', True)]}"/>
                 </group>
             </xpath>
         </field>

--- a/product_stock_state/views/product_template_view.xml
+++ b/product_stock_state/views/product_template_view.xml
@@ -8,6 +8,7 @@
                 <group name="treshold" string="Stock Threshold">
                     <field name="stock_state_threshold" />
                     <field name="manual_stock_state_threshold" class="oe_edit_only" />
+                    <field name="on_demand" />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
1. **Manifest** updated
 
---

2. **Default value** of `on_demand`
    1.  set to `False`

---

3. **Tests** of `on_demand`
    1. **Test Default Value of `on_demand`**:
        - Ensures that the default value of the `on_demand` attribute on the product is `False`.
    2. **Test Inheritance and Setting of `on_demand`**:
        - Verifies that setting `on_demand` on a specific product instance correctly inherits and reflects its value when calling `_stock_state_check_on_demand()`.
    3. **Test Computation of Stock State When `on_demand` is `True`**:
        - Confirms that the computed stock state is set to `'on_demand'` regardless of the previous state, 

---

4. **Updated view** 'on demand' feature display in product.template view
    1. `state_thershold` not shown in view if `on_demand` is True

---

<img width="359" alt="image" src="https://github.com/user-attachments/assets/af20bc29-a812-48dd-a90c-f4502db08f69" />
